### PR TITLE
feat: share widget

### DIFF
--- a/facebook-share-widget.js
+++ b/facebook-share-widget.js
@@ -16,7 +16,7 @@ reearth.ui.show(
 <script async defer crossorigin="anonymous" src="https://connect.facebook.net/ja_JP/sdk.js#xfbml=1&version=v13.0" nonce="QhVE4Z3L"></script>
 
 <script>
-// recieve message
+	// recieve message
    window.addEventListener("message", e => {
     if (e.source !== parent) return;
     property = e.data.property;

--- a/facebook-share-widget.js
+++ b/facebook-share-widget.js
@@ -37,6 +37,7 @@ send();
 function send() {
   if (reearth.widget?.property?.default) {
     reearth.ui.postMessage({
+      type: "facebook",
       property: reearth.widget.property.default
     });
   }

--- a/facebook-share-widget.js
+++ b/facebook-share-widget.js
@@ -18,7 +18,7 @@ reearth.ui.show(
 <script>
 	// recieve message
    window.addEventListener("message", e => {
-    if (e.source !== parent) return;
+    if (e.source !== parent || !e.data || e.data.type !== "facebook") return;
     property = e.data.property;
     if (property) {
       let link = document.getElementById("facebook-share")

--- a/facebook-share-widget.js
+++ b/facebook-share-widget.js
@@ -24,7 +24,6 @@ reearth.ui.show(
       let link = document.getElementById("facebook-share")
       link.setAttribute('data-href', property.url);
     }
-    e.source.reearth.on();
   });
 </script>
 

--- a/facebook-share-widget.js
+++ b/facebook-share-widget.js
@@ -1,0 +1,44 @@
+reearth.ui.show(
+  `<style>
+      body { 
+        margin: 0;
+      }
+  </style>
+<!-- Facebook -->
+<div id="fb-root"></div>
+	<div class="fb-share-button" data-href="https://reearth.io/" data-layout="button" data-size="large" id="facebook-share">
+		<a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Freearth.io%2F&amp;src=sdkpreparse" class="fb-xfbml-parse-ignore">
+		Share
+		</a>
+	</div>
+</div>
+
+<script async defer crossorigin="anonymous" src="https://connect.facebook.net/ja_JP/sdk.js#xfbml=1&version=v13.0" nonce="QhVE4Z3L"></script>
+
+<script>
+// recieve message
+   window.addEventListener("message", e => {
+    if (e.source !== parent) return;
+    property = e.data.property;
+    if (property) {
+      let link = document.getElementById("facebook-share")
+      link.setAttribute('data-href', property.url);
+    }
+    e.source.reearth.on();
+  });
+</script>
+
+  `
+  , { visible: true });
+
+// post message
+reearth.on("update", send);
+send();
+
+function send() {
+  if (reearth.widget?.property?.default) {
+    reearth.ui.postMessage({
+      property: reearth.widget.property.default
+    });
+  }
+}

--- a/reearth.yml
+++ b/reearth.yml
@@ -46,3 +46,29 @@ extensions:
   - id: tagcloud
     type: widget
     name: Tag Cloud
+  - id: tweet-widget
+    type: widget
+    name: Tweet Widget
+    schema:
+      groups:
+        - id: default
+          fields:
+            - id: url
+              type: string
+              title: URL
+            - id: hashtags
+              type: string
+              title: Hashtag
+            - id: text
+              type: string
+              title: Text
+  - id: facebook-share-widget
+    type: widget
+    name: Facebook Share Widget
+    schema:
+      groups:
+        - id: default
+          fields:
+            - id: url
+              type: string
+              title: URL

--- a/tweet-widget.js
+++ b/tweet-widget.js
@@ -48,6 +48,7 @@ send();
 function send() {
   if (reearth.widget?.property?.default) {
     reearth.ui.postMessage({
+      type: "twitter",
       property: reearth.widget.property.default
     });
   }

--- a/tweet-widget.js
+++ b/tweet-widget.js
@@ -30,7 +30,6 @@ reearth.ui.show(
       link.setAttribute('data-hashtags', property.hashtags);
       link.setAttribute('data-text', property.text);
     }
-    e.source.reearth.on();
   });
 
   !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');

--- a/tweet-widget.js
+++ b/tweet-widget.js
@@ -22,7 +22,7 @@ reearth.ui.show(
 
   // recieve message
    window.addEventListener("message", e => {
-    if (e.source !== parent) return;
+    if (e.source !== parent || !e.data || e.data.type !== "twitter") return;
     property = e.data.property;
     if (property.url) {
       let link = document.getElementById("twitter-button")

--- a/tweet-widget.js
+++ b/tweet-widget.js
@@ -1,0 +1,56 @@
+reearth.ui.show(
+  `<style>
+      body { 
+        margin: 0;
+      }
+  </style>
+
+  <!-- Twitter -->
+
+  <a class="twitter-share-button"
+    href="https://twitter.com/intent/tweet"
+    data-size="large"
+    data-text="Default text"
+    data-url="https://reearth.io/"
+    data-hashtags="reearth"
+    data-lang="ja"
+    data-dnt="true"
+    id="twitter-button">
+  Tweet
+  </a>
+  <script>
+
+  // recieve message
+   window.addEventListener("message", e => {
+    if (e.source !== parent) return;
+    property = e.data.property;
+    if (property.url) {
+      let link = document.getElementById("twitter-button")
+      link.setAttribute('data-url', property.url);
+      link.setAttribute('data-hashtags', property.hashtags);
+      link.setAttribute('data-text', property.text);
+    }
+    e.source.reearth.on();
+  });
+
+  !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
+  </script>
+
+
+  `
+
+  , { visible: true });
+
+
+// post message
+reearth.on("update", send);
+send();
+
+function send() {
+  if (reearth.widget?.property?.default) {
+    reearth.ui.postMessage({
+      property: reearth.widget.property.default
+    });
+  }
+}
+


### PR DESCRIPTION
## Changes proposed in this pull request
- Add 2  sample widget plugin


## Twitter share widget plugin
### Properties
- URL: Share URL you want
- Hashtags: Add a comma-separated list of hashtags to a Tweet using the hashtags parameter.
- Text: Default text in a Tweet.

<img width="452" alt="image" src="https://user-images.githubusercontent.com/13118515/165708932-6d2cdd83-b03d-4be9-bde2-72781fa48f51.png">

## Facebook share widget plugin
### Properties
- URL: Share URL you want
<img width="454" alt="image" src="https://user-images.githubusercontent.com/13118515/165710655-3b03d798-5bd2-426d-a594-737852c2198b.png">

## Remaining issues
I don't know why I have to re-checked widget toggle after set properties to refresh.


![タイトルなし](https://user-images.githubusercontent.com/13118515/165717130-85a94f0a-19f4-452b-84fa-816ce821c456.gif)

